### PR TITLE
Refactor to use UIContext in core

### DIFF
--- a/core/app_state.py
+++ b/core/app_state.py
@@ -17,7 +17,8 @@ class UIContext:
         self.is_custom_asya = tk.BooleanVar(value=False)
         self.asya_name_var = tk.StringVar()
         self.asya_gender_var = tk.StringVar()
-        self.selected_theme = tk.StringVar(value="Светлая")
+        self.current_theme_name = "Светлая"
+        self.selected_theme = tk.StringVar(value=self.current_theme_name)
 
         # Хранилище виджетов
         self.fields: dict[str, tk.Widget] = {}

--- a/logic.py
+++ b/logic.py
@@ -12,7 +12,7 @@ from ui_helpers import (add_field,
                         add_time_range_dropdown)
 
 
-from ui_state import UIContext
+from core.app_state import UIContext
 
 from constants import rooms_by_bz
 from utils import parse_yandex_calendar_url, format_date_ru, validate_fields
@@ -164,31 +164,31 @@ def generate_message(ctx: UIContext):
 
 
 def update_fields(*args, ctx: UIContext):
-    clear_frame()
+    clear_frame(ctx)
     typ = ctx.type_var.get()
     
 
     if typ == "Актуализация":
-        add_name_field_with_asya("Имя:", "name")
-        add_field_with_clear_button("Ссылка на встречу:", "link")
-        add_date_field("Дата (выбери в календаре):", "datetime")
-        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time")
-        add_dropdown_field("БЦ:", "bz", list(rooms_by_bz.keys()))
-        add_smart_filter_field("Переговорка:", "room", "bz")
-        add_dropdown_field("Тип встречи (Обычная/Регулярная):", "regular", ["Обычная", "Регулярная"])
+        add_name_field_with_asya(ctx, "Имя:", "name")
+        add_field_with_clear_button("Ссылка на встречу:", "link", ctx)
+        add_date_field("Дата (выбери в календаре):", "datetime", ctx)
+        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time", ctx)
+        add_dropdown_field("БЦ:", "bz", list(rooms_by_bz.keys()), ctx)
+        add_smart_filter_field("Переговорка:", "room", "bz", ctx)
+        add_dropdown_field("Тип встречи (Обычная/Регулярная):", "regular", ["Обычная", "Регулярная"], ctx)
 
     elif typ == "Обмен":
-        add_name_field_with_asya("Имя:", "name")
-        add_field_with_clear_button("Ссылка на встречу:", "link")
-        add_date_field("Дата (выбери в календаре):", "datetime")
-        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time")
+        add_name_field_with_asya(ctx, "Имя:", "name")
+        add_field_with_clear_button("Ссылка на встречу:", "link", ctx)
+        add_date_field("Дата (выбери в календаре):", "datetime", ctx)
+        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time", ctx)
 
         # Один выпадающий список для БЦ
-        add_dropdown_field("БЦ:", "bz", list(rooms_by_bz.keys()))
+        add_dropdown_field("БЦ:", "bz", list(rooms_by_bz.keys()), ctx)
 
         # Добавляем оба поля переговорок (his_room и my_room)
-        add_smart_filter_field("Его переговорка:", "his_room", "bz")
-        add_smart_filter_field("Твоя переговорка:", "my_room", "bz")
+        add_smart_filter_field("Его переговорка:", "his_room", "bz", ctx)
+        add_smart_filter_field("Твоя переговорка:", "my_room", "bz", ctx)
 
         # Обновлять оба списка при смене БЦ
         def update_all_rooms(*_):
@@ -203,21 +203,21 @@ def update_fields(*args, ctx: UIContext):
         update_all_rooms()
 
 
-        add_dropdown_field("Тип встречи (Обычная/Регулярная):", "regular", ["Обычная", "Регулярная"])
+        add_dropdown_field("Тип встречи (Обычная/Регулярная):", "regular", ["Обычная", "Регулярная"], ctx)
 
     elif typ == "Разовая встреча":
-        add_name_field_with_asya("Имя:", "name")
-        add_field_with_clear_button("Ссылка на встречу:", "link")
-        add_field("Название встречи:", "meeting_name")
-        add_field("Продолжительность встречи (например: 30 минут, 1 час, полтора часа):", "duration")
-        add_date_field("Предварительная дата, на которую поставилена встреча:", "datetime")
-        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time")
-        add_field_with_clear_button("Ссылка на пересекающуюся встречу 1:", "conflict1")
-        add_field_with_clear_button("Ссылка на пересекающуюся встречу 2 (необязательно):", "conflict2")
-        add_field_with_clear_button("Ссылка на пересекающуюся встречу 3 (необязательно):", "conflict3")
-        add_field("Имя и фамилия заказчика в родительном падеже (например: Андрея Романовского):", "client_name")
+        add_name_field_with_asya(ctx, "Имя:", "name")
+        add_field_with_clear_button("Ссылка на встречу:", "link", ctx)
+        add_field("Название встречи:", "meeting_name", ctx)
+        add_field("Продолжительность встречи (например: 30 минут, 1 час, полтора часа):", "duration", ctx)
+        add_date_field("Предварительная дата, на которую поставилена встреча:", "datetime", ctx)
+        add_time_range_dropdown("Время начала встречи:       ", "Время окончания встречи:", "start_time", "end_time", ctx)
+        add_field_with_clear_button("Ссылка на пересекающуюся встречу 1:", "conflict1", ctx)
+        add_field_with_clear_button("Ссылка на пересекающуюся встречу 2 (необязательно):", "conflict2", ctx)
+        add_field_with_clear_button("Ссылка на пересекающуюся встречу 3 (необязательно):", "conflict3", ctx)
+        add_field("Имя и фамилия заказчика в родительном падеже (например: Андрея Романовского):", "client_name", ctx)
     
-    apply_theme()
+    apply_theme(ctx)
 
 def on_link_change(*args, ctx: UIContext):
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from ui_state import UIContext
+from core.app_state import UIContext
 from ui import build_ui
 
 if __name__ == "__main__":

--- a/ocr.py
+++ b/ocr.py
@@ -4,9 +4,8 @@ from PIL import ImageGrab
 from tkinter import messagebox
 import tkinter as tk
 from datetime import datetime
-from ui_state import fields, type_var
 from constants import rooms_by_bz
-from ui_state import UIContext
+from core.app_state import UIContext
 
 import easyocr
 reader = easyocr.Reader(['ru', 'en'])

--- a/themes.py
+++ b/themes.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 
-from ui_state import UIContext
+from core.app_state import UIContext
 from widgets import AutocompleteCombobox  # если ты вынес его туда
 
 
@@ -53,7 +53,7 @@ themes = {
 
 def apply_theme(ctx: UIContext):
     style = ttk.Style()
-    theme = themes[current_theme_name]
+    theme = themes[ctx.current_theme_name]
     ctx.root.configure(bg=theme["bg"])
     style.configure("Custom.TFrame", background=theme["bg"])
     frame = ttk.Frame(ctx.fields_frame, style="Custom.TFrame")
@@ -141,6 +141,5 @@ def apply_theme(ctx: UIContext):
                           insertbackground=theme["fg"])
     
 def apply_theme_from_dropdown(*_, ctx: UIContext):
-    global current_theme_name
-    current_theme_name = ctx.selected_theme.get()
-    apply_theme()
+    ctx.current_theme_name = ctx.selected_theme.get()
+    apply_theme(ctx)

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -1,9 +1,8 @@
 from tkinter import ttk, messagebox
 import tkinter as tk
 from widgets import AutocompleteCombobox
-from ui_state import input_fields, fields, fields_frame, link_var, asya_mode, type_var
 from constants import rooms_by_bz
-from ui_state import UIContext
+from core.app_state import UIContext
 
 def add_time_range_dropdown(label_text_start: str, label_text_end: str, var_start: str, var_end: str, ctx: UIContext):
     start_combo = _create_time_selector(label_text_start)
@@ -139,7 +138,7 @@ def add_field_with_clear_button(label_text, var_name, ctx: UIContext):
     frame = ttk.Frame(ctx.fields_frame, style="Custom.TFrame")
     frame.pack(fill="x", padx=10, pady=2)
 
-    entry_var = link_var if var_name == "link" else tk.StringVar()
+    entry_var = ctx.link_var if var_name == "link" else tk.StringVar()
     entry = ttk.Entry(frame, textvariable=entry_var, style="TEntry")
     entry.pack(side="left", fill="x", expand=True)
 
@@ -291,7 +290,7 @@ def add_name_field_with_asya(ctx: UIContext, label_text="Имя:", var_name="nam
     name_entry.pack(side="left", fill="x", expand=True)
 
     # Кнопка "Ася +"
-    asya_check = ttk.Checkbutton(frame, text="Ася +", variable=asya_mode, style="TCheckbutton")
+    asya_check = ttk.Checkbutton(frame, text="Ася +", variable=ctx.asya_mode, style="TCheckbutton")
     asya_check.pack(side="left", padx=(5, 0))
 
     ctx.fields["name"] = name_entry

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import pygame
 from ui_helpers import focus_next
-from ui_state import UIContext
+from core.app_state import UIContext
 
 
 
@@ -25,19 +25,19 @@ def toggle_music(music_button, ctx: UIContext):
         print("[INFO] Музыка не загружена — ничего не делаем.")
         return
 
-    if not ctx.state["playing"]:
+    if not ctx.music_state["playing"]:
         pygame.mixer.music.play(-1)
         music_button.config(text="⏸")
-        ctx.state["playing"] = True
-        ctx.state["paused"] = False
-    elif not ctx.state["paused"]:
+        ctx.music_state["playing"] = True
+        ctx.music_state["paused"] = False
+    elif not ctx.music_state["paused"]:
         pygame.mixer.music.pause()
         music_button.config(text="▶️")
-        ctx.state["paused"] = True
+        ctx.music_state["paused"] = True
     else:
         pygame.mixer.music.unpause()
         music_button.config(text="⏸")
-        ctx.state["paused"] = False
+        ctx.music_state["paused"] = False
 
 
 def parse_yandex_calendar_url(url):


### PR DESCRIPTION
## Summary
- move `ui_state.py` to `core/app_state.py`
- expose `current_theme_name` inside `UIContext`
- update imports to use `core.app_state`
- remove global state usage in `ui.py`
- pass context to callbacks and utilities
- use `ctx.music_state` for music state management
- adjust theming helpers to rely on context

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684190dfedbc8331b8ad598c3ebda0fb