### PR TITLE
Fix callbacks and init pygame mixer

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -36,7 +36,7 @@ def generate_message(ctx: UIContext):
     else:
         required_keys = []
 
-    if not validate_fields(required_keys):
+    if not validate_fields(required_keys, ctx):
         return
 
     if start and end:

--- a/ui.py
+++ b/ui.py
@@ -36,6 +36,13 @@ def init_music(filename: str) -> str | None:
 
 
 def build_ui(ctx: UIContext):
+    pygame.init()
+    try:
+        pygame.mixer.init()
+    except Exception as e:
+        print(f"[ERROR] Failed to init mixer: {e}")
+
+    ctx.music_path = init_music(ctx.music_path)
 
     style = ttk.Style()
     style.theme_use("clam")
@@ -53,11 +60,11 @@ def build_ui(ctx: UIContext):
         style="Custom.TCombobox"
     )
     theme_selector.pack(pady=(0, 5))
-    theme_selector.bind("<<ComboboxSelected>>", apply_theme_from_dropdown)
+    theme_selector.bind("<<ComboboxSelected>>", lambda *_: apply_theme_from_dropdown(ctx=ctx))
 
     # === Тип встречи ===
     ctx.type_var = tk.StringVar()
-    ctx.type_var.trace_add("write", lambda *_: update_fields(ctx))
+    ctx.type_var.trace_add("write", lambda *_: update_fields(ctx=ctx))
 
     ttk.Label(ctx.root, text="Тип встречи:", style="TLabel").pack(anchor="w", padx=10, pady=(10, 0))
 
@@ -73,7 +80,7 @@ def build_ui(ctx: UIContext):
 
     # === Ссылка ===
     ctx.link_var = tk.StringVar()
-    ctx.link_var.trace_add("write", lambda *_: on_link_change(ctx))
+    ctx.link_var.trace_add("write", lambda *_: on_link_change(ctx=ctx))
 
     # === Ася блок ===
     ctx.asya_mode = tk.BooleanVar(value=False)


### PR DESCRIPTION
## Summary
- pass ctx to validation helper
- init pygame mixer and load music file
- use keyworded callbacks for Tkinter traces

## Testing
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'easyocr')*

------
https://chatgpt.com/codex/tasks/task_e_684198f4dfcc83319ace25e09de3de6f