### PR TITLE
Fix clipboard paste and handle missing date

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from tkinter import messagebox
 from datetime import datetime
 import random
 from ui_helpers import (add_field, 
@@ -47,6 +48,11 @@ def generate_message(ctx: UIContext):
         time_part = ""
 
     name = field_values.get("name", "")
+
+    if "datetime" not in ctx.fields:
+        messagebox.showerror("Ошибка", "Сначала выберите тип встречи")
+        return
+
     raw_date = ctx.fields["datetime"].get_date()
     formatted = format_date_ru(raw_date)
     link = field_values.get("link", "")

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -98,11 +98,11 @@ def enable_ctrl_c(widget, root):
 
     widget.bind("<Button-3>", show_menu)
 
-def enable_ctrl_v(widget, root):
+def enable_ctrl_v(widget):
     def paste_clipboard(event=None):
         try:
-            widget.insert(tk.INSERT, root.clipboard_get())
-        except:
+            widget.insert(tk.INSERT, widget.clipboard_get())
+        except tk.TclError:
             pass
         return "break"
 


### PR DESCRIPTION
## Summary
- fix `enable_ctrl_v` signature
- show an error when `datetime` field is missing

## Testing
- `pytest -q`
- `python -m py_compile ui_helpers.py logic.py ui.py main.py utils.py core/app_state.py`

------
https://chatgpt.com/codex/tasks/task_e_68419b89dc7c8331b78dcc5692ba723e