### PR TITLE
Add 'Ася +' toggle and align buttons

### DIFF
--- a/core/app_state.py
+++ b/core/app_state.py
@@ -30,6 +30,8 @@ class UIContext:
         self.asya_extra_frame: ttk.Frame | None = None  # legacy, no longer packed
         self.asya_popup: tk.Toplevel | None = None
         self.asya_button: ttk.Button | None = None
+        self.asya_mode_button: ttk.Button | None = None
+        self.action_frame: ttk.Frame | None = None
         self.custom_asya_saved: bool = False
         self.custom_asya_on: bool = False
 

--- a/logic.py
+++ b/logic.py
@@ -357,3 +357,19 @@ def update_asya_button(ctx: UIContext):
     else:
         text = "ЛС"
     ctx.asya_button.config(text=text)
+
+
+def toggle_asya_mode(ctx: UIContext):
+    """Toggle the simple Ася mode."""
+    ctx.asya_mode.set(not ctx.asya_mode.get())
+    update_asya_mode_button(ctx)
+
+
+def update_asya_mode_button(ctx: UIContext):
+    """Update the Ася + toggle button."""
+    if not ctx.asya_mode_button:
+        return
+    active = ctx.asya_mode.get()
+    text = "Ася +: вкл" if active else "Ася +: выкл"
+    style = "Accent.TButton" if active else "Custom.TButton"
+    ctx.asya_mode_button.config(text=text, style=style)

--- a/themes.py
+++ b/themes.py
@@ -87,6 +87,21 @@ def apply_theme(ctx: UIContext):
     style.map("Custom.TButton",
         background=[("active", theme["highlight"])],
         foreground=[("active", theme["fg"])])
+
+    # Accent style for toggle buttons
+    style.configure(
+        "Accent.TButton",
+        background=theme["highlight"],
+        foreground=theme["fg"],
+        borderwidth=1,
+        focusthickness=1,
+        focuscolor=theme["highlight"],
+    )
+    style.map(
+        "Accent.TButton",
+        background=[("active", theme["highlight"])],
+        foreground=[("active", theme["fg"])]
+    )
   
 
     style.configure("Custom.DateEntry",

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,16 @@
 from tkinter import ttk, messagebox
 import tkinter as tk
 from themes import themes, apply_theme_from_dropdown
-from logic import generate_message, update_fields, on_link_change, toggle_custom_asya, save_custom_asya, update_asya_button
+from logic import (
+    generate_message,
+    update_fields,
+    on_link_change,
+    toggle_custom_asya,
+    save_custom_asya,
+    update_asya_button,
+    toggle_asya_mode,
+    update_asya_mode_button,
+)
 from ocr import import_from_clipboard_image
 from utils import toggle_music, copy_generated_text, translate_to_english
 from ui_helpers import clear_frame, focus_next, enable_ctrl_v, enable_ctrl_c
@@ -89,21 +98,27 @@ def build_ui(ctx: UIContext):
     ctx.asya_popup = None
     ctx.asya_extra_frame = None
 
-    ctx.asya_button = ttk.Button(
-        ctx.root,
-        text="ЛС",
-        command=lambda: toggle_custom_asya(ctx),
-        style="Custom.TButton"
-    )
-    ctx.asya_button.pack(anchor="e", padx=10)
-    update_asya_button(ctx)
-
     # === Поля ===
     ctx.fields_frame = ttk.Frame(ctx.root, style="Custom.TFrame")
     ctx.fields_frame.pack(fill="x", expand=True, padx=10, pady=10)
 
     # === Кнопки ===
-    generate_button = ttk.Button(ctx.root, text="Сгенерировать сообщение", command=lambda: generate_message(ctx))
+    ctx.action_frame = ttk.Frame(ctx.root, style="Custom.TFrame")
+    ctx.action_frame.pack(pady=(5, 2))
+
+    generate_button = ttk.Button(ctx.action_frame, text="Сгенерировать сообщение", command=lambda: generate_message(ctx))
+    ctx.asya_button = ttk.Button(
+        ctx.action_frame,
+        text="ЛС",
+        command=lambda: toggle_custom_asya(ctx),
+        style="Custom.TButton",
+    )
+    ctx.asya_mode_button = ttk.Button(
+        ctx.action_frame,
+        text="Ася +",
+        command=lambda: toggle_asya_mode(ctx),
+        style="Custom.TButton",
+    )
     copy_button = ttk.Button(ctx.root, text="Скопировать текст", command=lambda: copy_generated_text(ctx, ctx.root))
 
     music_button = ttk.Button(
@@ -124,7 +139,12 @@ def build_ui(ctx: UIContext):
     clipboard_button.pack(anchor="e", padx=10, pady=(0, 5))
     ctx.input_fields.append(clipboard_button)
 
-    generate_button.pack(pady=(5, 2))
+    generate_button.pack(side="left")
+    ctx.asya_button.pack(side="left", padx=(5, 0))
+    ctx.asya_mode_button.pack(side="left", padx=(5, 0))
+    update_asya_button(ctx)
+    update_asya_mode_button(ctx)
+
     copy_button.pack(pady=(0, 10))
 
     # === Output ===

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -289,13 +289,8 @@ def add_name_field_with_asya(ctx: UIContext, label_text="Имя:", var_name="nam
     name_entry = ttk.Entry(frame, textvariable=name_var, style="TEntry")
     name_entry.pack(side="left", fill="x", expand=True)
 
-    # Кнопка "Ася +"
-    asya_check = ttk.Checkbutton(frame, text="Ася +", variable=ctx.asya_mode, style="TCheckbutton")
-    asya_check.pack(side="left", padx=(5, 0))
-
     ctx.fields["name"] = name_entry
     ctx.input_fields.append(name_entry)
-    ctx.input_fields.append(asya_check)
 
     def focus_next(event):
         name_entry.tk_focusNext().focus()


### PR DESCRIPTION
## Summary
- add action frame for the main buttons
- place 'ЛС' and new 'Ася +' toggle next to 'Сгенерировать сообщение'
- create toggle logic and styles for 'Ася +'
- update theme with accent button style
- adjust UI context fields and helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6841fec826948331aec51c9537d01e1c