### PR TITLE
Fix Tuesday grammar in Russian date

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -78,7 +78,11 @@ def format_date_ru(date_obj):
             day_name = days[date_obj.weekday()]
             day = date_obj.day
             month = months[date_obj.month - 1]
-            return f"в {day_name}, {day} {month}"
+
+            # "во" используется перед вторником для правильного звучания
+            preposition = "во" if day_name == "вторник" else "в"
+
+            return f"{preposition} {day_name}, {day} {month}"
     except Exception as e:
         print(f"[ERROR] Невозможно отформатировать дату: {e}")
         return ""


### PR DESCRIPTION
## Summary
- correct `format_date_ru` so that Tuesday is formatted with "во" instead of "в"

## Testing
- `python -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684201a57950833191235d23b8f8043d