### PR TITLE
Add themed background images with dynamic scaling

### DIFF
--- a/core/app_state.py
+++ b/core/app_state.py
@@ -48,6 +48,10 @@ class UIContext:
         self.bg_image_tk = None
         self.bg_image_path: str | None = None
 
+        # Кеширование и дебаунс фоновой картинки
+        self.bg_resize_cache: dict = {}
+        self.bg_update_after_id: str | None = None
+
     def reset_fields(self):
         """Полностью очищает поля формы"""
         for widget in self.fields_frame.winfo_children():

--- a/ui.py
+++ b/ui.py
@@ -1,6 +1,10 @@
 from tkinter import ttk, messagebox
 import tkinter as tk
-from themes import themes, apply_theme_from_dropdown, update_background
+from themes import (
+    themes,
+    apply_theme_from_dropdown,
+    debounced_update_background,
+)
 from logic import (
     generate_message,
     update_fields,
@@ -60,7 +64,7 @@ def build_ui(ctx: UIContext):
     ctx.bg_label = tk.Label(ctx.root)
     ctx.bg_label.place(relx=0, rely=0, relwidth=1, relheight=1)
     ctx.bg_label.lower()
-    ctx.root.bind("<Configure>", lambda e: update_background(ctx))
+    ctx.root.bind("<Configure>", lambda e: debounced_update_background(ctx))
 
     # === Тема ===
     ctx.current_theme_name = "Светлая"


### PR DESCRIPTION
## Summary
- attach background image per theme
- resize background image when window changes
- make overlay frames semi-transparent
- initialize theme after building UI

## Testing
- `python -m py_compile *.py core/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6842891b8fac8331bc852bdb85c6ccf2