### PR TITLE
Replace EasyOCR with pytesseract and add PySide6 UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
      ```bash
      DEEPL_API_KEY=ваш_ключ_от_deepl
      ```
-4. **Запускайте программу**
+4. **Запускайте программу (версия PySide6)**
    ```bash
-   python main.py
+   python main_qt.py
    ```
 
 ---

--- a/core/qt_app_state.py
+++ b/core/qt_app_state.py
@@ -1,0 +1,11 @@
+from PySide6.QtWidgets import QApplication, QWidget
+
+class QtUIContext:
+    """Storage for PySide6 UI widgets."""
+
+    def __init__(self):
+        self.app = QApplication.instance() or QApplication([])
+        self.window = QWidget()
+        self.fields: dict[str, QWidget] = {}
+        self.input_fields: list[QWidget] = []
+        self.type_box = None

--- a/main_qt.py
+++ b/main_qt.py
@@ -1,0 +1,14 @@
+from core.qt_app_state import QtUIContext
+from qt_ui import build_ui
+
+
+def main():
+    ctx = QtUIContext()
+    build_ui(ctx)
+    ctx.window.setWindowTitle("Генератор шаблонов встреч (Qt)")
+    ctx.window.show()
+    ctx.app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/ocr_tesseract.py
+++ b/ocr_tesseract.py
@@ -1,0 +1,138 @@
+import re
+from datetime import datetime
+from typing import List
+
+from PIL import Image, ImageDraw
+import pytesseract
+from pytesseract import Output
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import QMessageBox
+
+from constants import rooms_by_bz
+
+
+def grab_clipboard_image() -> Image.Image | None:
+    clipboard = QGuiApplication.clipboard()
+    if clipboard.mimeData().hasImage():
+        qimage = clipboard.image()
+        if qimage.isNull():
+            return None
+        return Image.fromqimage(qimage)
+    return None
+
+
+def extract_fields_from_text(texts: List[str]):
+    name = ""
+    bz = ""
+    room = ""
+    start_time = ""
+    end_time = ""
+    date = ""
+
+    for i, txt in enumerate(texts):
+        if "организатор" in txt.lower() and i + 1 < len(texts):
+            full_name = texts[i + 1]
+            name = full_name.split()[0]
+
+    found_times = []
+    for txt in texts:
+        cleaned = re.sub(r"[^0-9]", ":", txt.strip())
+        if re.fullmatch(r"\d{2}:\d{2}", cleaned):
+            found_times.append(cleaned)
+            if len(found_times) == 2:
+                break
+    if len(found_times) == 2:
+        start_time, end_time = found_times
+
+    for txt in texts:
+        if re.fullmatch(r"\d{2}\.\d{2}\.\d{4}", txt.strip()):
+            date = txt.strip()
+            break
+
+    for txt in texts:
+        if "морозов" in txt.lower():
+            bz = "БЦ Морозов"
+
+    flat_rooms = []
+    for bz_key, rooms in rooms_by_bz.items():
+        for room_name in rooms:
+            flat_rooms.append((bz_key, room_name))
+
+    for txt in texts:
+        txt_lower = txt.lower()
+        for bz_key, room_name in flat_rooms:
+            short = room_name.split(".")[-1].split()[0].lower()
+            if short and short in txt_lower and len(short) > 3:
+                room = room_name
+                bz = bz_key
+                break
+
+    return name, bz, room, date, start_time, end_time
+
+
+def is_checkbox_checked(image: Image.Image, x: int, y: int, size: int = 12, threshold: int = 200, fill_threshold: float = 0.2) -> bool:
+    cropped = image.crop((x, y, x + size, y + size)).convert("L")
+    pixels = list(cropped.getdata())
+    dark_pixels = sum(1 for p in pixels if p < threshold)
+    fill_ratio = dark_pixels / len(pixels)
+    print(f"[DEBUG] fill_ratio: {fill_ratio:.2f}")
+    return fill_ratio > fill_threshold
+
+
+def detect_repeat_checkbox(image: Image.Image, ocr_data) -> bool:
+    print("[DEBUG] Начинаем поиск чекбокса...")
+    n = len(ocr_data['text'])
+    for i in range(n):
+        text = ocr_data['text'][i]
+        if text and text.strip().lower() == "повторять":
+            print("[DEBUG] Найдено слово 'повторять'")
+            x = ocr_data['left'][i] - 15
+            y = ocr_data['top'][i] + 11
+            print(f"[DEBUG] Координаты для анализа чекбокса: x={x}, y={y}")
+            draw = ImageDraw.Draw(image)
+            draw.rectangle([x - 10, y - 10, x + 10, y + 10], outline="red")
+            image.save("checkbox_debug.png")
+            return is_checkbox_checked(image, x, y)
+    print("[DEBUG] Слово 'повторять' не найдено вообще.")
+    return False
+
+
+def import_from_clipboard_image(ctx):
+    meeting_type = ctx.type_box.currentText() if hasattr(ctx, 'type_box') else ''
+    print(f"[DEBUG] Тип встречи: {meeting_type}")
+    image = grab_clipboard_image()
+    if image is None:
+        QMessageBox.critical(ctx.window if hasattr(ctx, 'window') else None, "Ошибка", "Буфер обмена не содержит изображения.")
+        return
+    print("[DEBUG] Буфер получен")
+    data = pytesseract.image_to_data(image, lang='rus', output_type=Output.DICT)
+    texts = [t for t in data['text'] if t.strip()]
+    print("[DEBUG] Текст распознан:", texts)
+    name, bz, room, date, start_time, end_time = extract_fields_from_text(texts)
+    is_regular = "Регулярная" if detect_repeat_checkbox(image, data) else "Обычная"
+
+    if 'name' in ctx.fields and name:
+        ctx.fields['name'].setText(name)
+    if bz:
+        if bz not in rooms_by_bz:
+            rooms_by_bz[bz] = []
+        if 'bz' in ctx.fields:
+            ctx.fields['bz'].setCurrentText(bz)
+    if meeting_type == 'Обмен':
+        if 'his_room' in ctx.fields and room:
+            ctx.fields['his_room'].setCurrentText(room)
+    else:
+        if 'room' in ctx.fields and room:
+            ctx.fields['room'].setCurrentText(room)
+    if 'datetime' in ctx.fields and date:
+        try:
+            ctx.fields['datetime'].setDate(datetime.strptime(date, "%d.%m.%Y"))
+        except Exception as e:
+            print("Ошибка даты:", e)
+    if 'start_time' in ctx.fields and start_time:
+        ctx.fields['start_time'].setCurrentText(start_time)
+    if 'end_time' in ctx.fields and end_time:
+        ctx.fields['end_time'].setCurrentText(end_time)
+    if 'regular' in ctx.fields:
+        ctx.fields['regular'].setCurrentText(is_regular)
+    print("[DEBUG] Вставка завершена")

--- a/qt_ui.py
+++ b/qt_ui.py
@@ -1,0 +1,62 @@
+from PySide6.QtWidgets import (
+    QVBoxLayout, QLabel, QLineEdit, QComboBox, QPushButton, QDateEdit
+)
+from datetime import datetime
+
+from constants import rooms_by_bz
+from core.qt_app_state import QtUIContext
+from ocr_tesseract import import_from_clipboard_image
+
+
+def _generate_time_slots(start_hour: int = 8, end_hour: int = 22):
+    return [f"{h:02d}:{m:02d}" for h in range(start_hour, end_hour) for m in (0, 30)]
+
+
+def build_ui(ctx: QtUIContext):
+    layout = QVBoxLayout(ctx.window)
+
+    ctx.type_box = QComboBox()
+    ctx.type_box.addItems(["Актуализация", "Обмен", "Разовая встреча"])
+    layout.addWidget(QLabel("Тип встречи"))
+    layout.addWidget(ctx.type_box)
+
+    ctx.fields['name'] = QLineEdit()
+    layout.addWidget(QLabel("Имя"))
+    layout.addWidget(ctx.fields['name'])
+
+    date_edit = QDateEdit()
+    date_edit.setCalendarPopup(True)
+    date_edit.setDate(datetime.today())
+    ctx.fields['datetime'] = date_edit
+    layout.addWidget(QLabel("Дата"))
+    layout.addWidget(date_edit)
+
+    start_combo = QComboBox(); start_combo.addItems(_generate_time_slots())
+    end_combo = QComboBox(); end_combo.addItems(_generate_time_slots())
+    ctx.fields['start_time'] = start_combo
+    ctx.fields['end_time'] = end_combo
+    layout.addWidget(QLabel("Время начала"))
+    layout.addWidget(start_combo)
+    layout.addWidget(QLabel("Время конца"))
+    layout.addWidget(end_combo)
+
+    bz_combo = QComboBox(); bz_combo.addItems(list(rooms_by_bz.keys()))
+    ctx.fields['bz'] = bz_combo
+    layout.addWidget(QLabel("Бизнес-центр"))
+    layout.addWidget(bz_combo)
+
+    room_combo = QComboBox(); room_combo.addItems(sum(rooms_by_bz.values(), []))
+    ctx.fields['room'] = room_combo
+    layout.addWidget(QLabel("Переговорка"))
+    layout.addWidget(room_combo)
+
+    reg_combo = QComboBox(); reg_combo.addItems(["Обычная", "Регулярная"])
+    ctx.fields['regular'] = reg_combo
+    layout.addWidget(QLabel("Тип"))
+    layout.addWidget(reg_combo)
+
+    btn = QPushButton("📋 Из буфера")
+    btn.clicked.connect(lambda: import_from_clipboard_image(ctx))
+    layout.addWidget(btn)
+
+    ctx.window.setLayout(layout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pygame
 requests
 Pillow
 tkcalendar
-easyocr
+PySide6
+pytesseract


### PR DESCRIPTION
## Summary
- switch requirements from easyocr to PySide6+pytesseract
- create PySide6 OCR module using pytesseract
- add minimal PySide6 context and UI
- provide `main_qt.py` to launch the new UI
- update README about running the Qt version

## Testing
- `python -m py_compile ocr_tesseract.py qt_ui.py main_qt.py core/qt_app_state.py`

------
https://chatgpt.com/codex/tasks/task_e_6842bfa4ed74833185739a637d978cb2