### PR TITLE
Improve fuzzy matching for meeting rooms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ easyocr<1.8
 torch<2.0
 torchvision<0.18
 PySide6
+rapidfuzz

--- a/tests/test_ocr_parse.py
+++ b/tests/test_ocr_parse.py
@@ -75,3 +75,10 @@ def test_parse_and_validate():
     assert validated["bz"] == "БЦ Морозов"
     assert validated["room"] == "1.Кофе"
 
+
+def test_room_fuzzy_matching():
+    fields = {"bz_raw": "БЦ Аврора", "room_raw": "2В Гостиная дя ."}
+    rooms_map = {"БЦ Аврора": ["2B.Гостиная дядюшки Скруджа"]}
+    validated = validate_with_rooms(fields, rooms_map, fuzzy_threshold=0.6)
+    assert validated["room"] == "2B.Гостиная дядюшки Скруджа"
+


### PR DESCRIPTION
## Summary
- enhance `validate_with_rooms` with RapidFuzz-based matching
- add room name normalization for fuzzy match
- log best candidate and top-3 alternatives
- add RapidFuzz to dependencies
- test fuzzy matching against typical OCR errors

## Testing
- `pip install numpy Pillow requests pygame PySide6 rapidfuzz`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446497acc483319763926e7263bccc