### PR TITLE
Improve room selection filtering

### DIFF
--- a/examples/room_filter_demo.py
+++ b/examples/room_filter_demo.py
@@ -1,0 +1,38 @@
+"""Minimal demo for FilteringComboBox."""
+from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel, QComboBox
+
+from logic.room_filter import FilteringComboBox
+
+rooms_map = {
+    "БЦ Морозов": ["1.Кофе", "1.Чай", "2.Близнецы"],
+    "БЦ Аврора": ["2B.Гостиная дядюшки Скруджа"],
+}
+
+
+class Demo(QWidget):
+    def __init__(self):
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        self.bz_combo = QComboBox()
+        self.bz_combo.addItems(rooms_map.keys())
+
+        self.room_combo = FilteringComboBox()
+
+        layout.addWidget(QLabel("БЦ:"))
+        layout.addWidget(self.bz_combo)
+        layout.addWidget(QLabel("Переговорка:"))
+        layout.addWidget(self.room_combo)
+
+        self.bz_combo.currentTextChanged.connect(self.update_rooms)
+        self.update_rooms(self.bz_combo.currentText())
+
+    def update_rooms(self, bz):
+        self.room_combo.set_items(rooms_map.get(bz, []))
+
+
+if __name__ == "__main__":
+    app = QApplication([])
+    demo = Demo()
+    demo.show()
+    app.exec()

--- a/logic/generator.py
+++ b/logic/generator.py
@@ -13,9 +13,10 @@ from PySide6.QtWidgets import (
     QTextEdit,
     QMessageBox,
     QToolButton,
-    QCompleter,
 )
-from PySide6.QtCore import QDate, QStringListModel
+from PySide6.QtCore import QDate
+
+from logic.room_filter import FilteringComboBox
 
 from logic.app_state import UIContext
 from constants import rooms_by_bz
@@ -80,19 +81,12 @@ def add_room_field(label: str, name: str, bz_name: str, ctx: UIContext):
     container = QWidget()
     hl = QHBoxLayout(container)
     lbl = QLabel(label)
-    combo = QComboBox()
-    combo.setEditable(True)
-    completer = QCompleter()
-    combo.setCompleter(completer)
-    model = QStringListModel()
-    completer.setModel(model)
+    combo = FilteringComboBox()
 
     def update_rooms():
         bz = ctx.fields.get(bz_name).currentText() if bz_name in ctx.fields else ''
         rooms = rooms_by_bz.get(bz, [])
-        model.setStringList(rooms)
-        combo.clear()
-        combo.addItems(rooms)
+        combo.set_items(rooms)
 
     if bz_name in ctx.fields:
         ctx.fields[bz_name].currentTextChanged.connect(update_rooms)

--- a/logic/room_filter.py
+++ b/logic/room_filter.py
@@ -1,0 +1,68 @@
+# Filtering utilities and combo box widget for meeting rooms
+from PySide6.QtWidgets import QComboBox
+
+
+# Mapping from English keyboard layout to Russian
+_EN_TO_RU = {
+    'q': 'й', 'w': 'ц', 'e': 'у', 'r': 'к', 't': 'е', 'y': 'н', 'u': 'г',
+    'i': 'ш', 'o': 'щ', 'p': 'з', '[': 'х', ']': 'ъ',
+    'a': 'ф', 's': 'ы', 'd': 'в', 'f': 'а', 'g': 'п', 'h': 'р', 'j': 'о',
+    'k': 'л', 'l': 'д', ';': 'ж', "'": 'э',
+    'z': 'я', 'x': 'ч', 'c': 'с', 'v': 'м', 'b': 'и', 'n': 'т', 'm': 'ь',
+    ',': 'б', '.': 'ю', '`': 'ё', '/': '.',
+    '<': 'Б', '>': 'Ю',
+}
+# add uppercase mapping
+_EN_TO_RU.update({k.upper(): v.upper() for k, v in list(_EN_TO_RU.items())})
+
+
+def fix_layout(text: str) -> str:
+    """Convert text typed in English layout to Russian layout."""
+    return ''.join(_EN_TO_RU.get(ch, ch) for ch in text)
+
+
+def filter_rooms(all_rooms: list[str], query: str) -> list[str]:
+    """Return rooms filtered according to prefix, substring and layout correction."""
+    if not query:
+        return list(all_rooms)
+    q = query.lower()
+    fixed = fix_layout(query).lower()
+
+    prefix = [r for r in all_rooms if r.lower().startswith(q)]
+    substring = [r for r in all_rooms if q in r.lower() and r not in prefix]
+
+    remaining = [r for r in all_rooms if r not in prefix + substring]
+    if fixed != q:
+        prefix_fixed = [r for r in remaining if r.lower().startswith(fixed)]
+        substring_fixed = [r for r in remaining if fixed in r.lower() and r not in prefix_fixed]
+    else:
+        prefix_fixed = []
+        substring_fixed = []
+
+    return prefix + substring + prefix_fixed + substring_fixed
+
+
+class FilteringComboBox(QComboBox):
+    """QComboBox with custom filtering logic for meeting rooms."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setEditable(True)
+        self._all_items: list[str] = []
+        self.lineEdit().textEdited.connect(self._on_text_edited)
+
+    def set_items(self, items: list[str]):
+        self._all_items = list(items)
+        self._apply_filter(self.lineEdit().text())
+
+    def _on_text_edited(self, text: str):
+        self._apply_filter(text)
+
+    def _apply_filter(self, text: str):
+        filtered = filter_rooms(self._all_items, text)
+        self.blockSignals(True)
+        self.clear()
+        self.addItems(filtered)
+        self.setEditText(text)
+        self.blockSignals(False)
+

--- a/tests/test_room_filter.py
+++ b/tests/test_room_filter.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# stub PySide6 for headless test environment
+qt_widgets = types.ModuleType('PySide6.QtWidgets')
+qt_widgets.QComboBox = object
+sys.modules['PySide6.QtWidgets'] = qt_widgets
+
+from logic.room_filter import filter_rooms
+
+rooms = ["1.Кофе", "1.Чай", "2.Близнецы"]
+
+
+def test_prefix_filter():
+    assert filter_rooms(rooms, "1.") == ["1.Кофе", "1.Чай"]
+
+
+def test_substring_filter():
+    assert filter_rooms(rooms, "Бли") == ["2.Близнецы"]
+
+
+def test_layout_correction():
+    assert filter_rooms(rooms, "<kb") == ["2.Близнецы"]


### PR DESCRIPTION
## Summary
- implement `FilteringComboBox` and `filter_rooms` with layout correction
- integrate new combo into generator UI
- provide a minimal example of the widget
- cover filtering logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a156c4908331869685eb7a0071b8