### PR TITLE
Add theming system and refactor UI

### DIFF
--- a/gui/music_dialog.py
+++ b/gui/music_dialog.py
@@ -1,0 +1,75 @@
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox,
+    QCheckBox, QPushButton, QMessageBox
+)
+import os
+import pygame
+
+from logic.app_state import UIContext
+
+
+class MusicDialog(QDialog):
+    """Simple dialog for music playback settings."""
+
+    TRACKS = [
+        "James.mp3",
+        "Track1.mp3",
+        "Track2.mp3",
+    ]
+
+    def __init__(self, ctx: UIContext, parent=None):
+        super().__init__(parent)
+        self.ctx = ctx
+        self.setWindowTitle("Музыка")
+
+        layout = QVBoxLayout(self)
+
+        self.enable_check = QCheckBox("Включить музыку")
+        self.enable_check.setChecked(ctx.music_state.get("playing", False))
+        layout.addWidget(self.enable_check)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Трек:"))
+        self.track_combo = QComboBox()
+        self.track_combo.addItems(self.TRACKS)
+        self.track_combo.setCurrentText(ctx.music_path)
+        row.addWidget(self.track_combo)
+        layout.addLayout(row)
+
+        self.listen_btn = QPushButton("🎧 Прослушать")
+        layout.addWidget(self.listen_btn)
+
+        self.enable_check.toggled.connect(self.toggle_music)
+        self.listen_btn.clicked.connect(self.preview)
+        self.track_combo.currentTextChanged.connect(self.change_track)
+
+    def change_track(self, name: str) -> None:
+        self.ctx.music_path = name
+
+    def toggle_music(self, checked: bool) -> None:
+        path = self.ctx.music_path
+        if checked:
+            self._play(path, loop=True)
+            self.ctx.music_state["playing"] = True
+            self.ctx.music_state["paused"] = False
+        else:
+            if pygame.mixer.get_init():
+                pygame.mixer.music.stop()
+            self.ctx.music_state["playing"] = False
+            self.ctx.music_state["paused"] = False
+
+    def preview(self) -> None:
+        path = self.track_combo.currentText()
+        self._play(path, loop=False)
+
+    def _play(self, path: str, loop: bool = False) -> None:
+        if not path or not os.path.exists(path):
+            QMessageBox.warning(self, "Ошибка", "Файл недоступен")
+            return
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
+        try:
+            pygame.mixer.music.load(path)
+            pygame.mixer.music.play(-1 if loop else 0)
+        except Exception as e:
+            QMessageBox.critical(self, "Ошибка", str(e))

--- a/gui/settings_window.py
+++ b/gui/settings_window.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import (
 )
 
 from logic.app_state import UIContext
+from gui.themes import THEME_QSS, apply_theme
 
 
 class SettingsDialog(QDialog):
@@ -29,9 +30,25 @@ class SettingsDialog(QDialog):
         row.addWidget(self.ocr_mode_combo)
         self.settings_layout.addLayout(row)
 
+        # theme selector
+        row_theme = QHBoxLayout()
+        row_theme.addWidget(QLabel("Тема:"))
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItem("Стандартная")
+        self.theme_combo.addItems(list(THEME_QSS.keys()))
+        self.theme_combo.setCurrentText(ctx.current_theme_name)
+        self.theme_combo.currentTextChanged.connect(self._on_theme_changed)
+        row_theme.addWidget(self.theme_combo)
+        self.settings_layout.addLayout(row_theme)
+
         ok_btn = QPushButton("OK")
         ok_btn.clicked.connect(self.accept)
         main_layout.addWidget(ok_btn)
 
     def _on_mode_changed(self, mode: str) -> None:
         self.ctx.ocr_mode = mode
+
+    def _on_theme_changed(self, name: str) -> None:
+        self.ctx.current_theme_name = name
+        if self.ctx.app:
+            apply_theme(self.ctx.app, name)

--- a/gui/themes.py
+++ b/gui/themes.py
@@ -1,0 +1,110 @@
+THEME_QSS = {
+    "Футуризм": """
+        * { font-family: 'Arial'; font-size: 14px; }
+        QMainWindow { background-color: #0d0d0d; color: #00ffcc; }
+        QPushButton { background-color: #111; color: #00ffcc; border-radius: 6px; padding: 4px; }
+        QPushButton:checked { background-color: #007766; }
+        QTextEdit { background-color: #222; color: #00ffcc; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Готика": """
+        * { font-family: 'Times New Roman'; font-size: 14px; }
+        QMainWindow { background-color: #1b0f16; color: #e0d6f5; }
+        QPushButton { background-color: #3a2440; color: #e0d6f5; border-radius: 4px; padding: 4px; }
+        QPushButton:checked { background-color: #5c3a6e; }
+        QTextEdit { background-color: #2b1a2f; color: #e0d6f5; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Киберпанк": """
+        * { font-family: 'Consolas'; font-size: 13px; }
+        QMainWindow { background-color: #050014; color: #ff00aa; }
+        QPushButton { background-color: #12003b; color: #ff00aa; border-radius: 6px; padding: 4px; }
+        QPushButton:checked { background-color: #ff0077; color: black; }
+        QTextEdit { background-color: #12003b; color: #ff00aa; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Минимал": """
+        * { font-family: 'Segoe UI'; font-size: 12px; }
+        QMainWindow { background-color: #f2f2f2; color: #202020; }
+        QPushButton { background-color: #e0e0e0; color: #202020; border-radius: 4px; padding: 4px; }
+        QPushButton:checked { background-color: #c2c2c2; }
+        QTextEdit { background-color: #ffffff; color: #202020; border-radius: 4px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Аниме": """
+        * { font-family: 'Comic Sans MS'; font-size: 13px; }
+        QMainWindow { background-color: #fff6fb; color: #ff4da6; }
+        QPushButton { background-color: #ffe1f0; color: #ff4da6; border-radius: 8px; padding: 4px; }
+        QPushButton:checked { background-color: #ffb3d9; }
+        QTextEdit { background-color: #ffffff; color: #ff4da6; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Гёрли": """
+        * { font-family: 'Verdana'; font-size: 13px; }
+        QMainWindow { background-color: #ffebf2; color: #d63384; }
+        QPushButton { background-color: #ffd6e8; color: #d63384; border-radius: 6px; padding: 4px; }
+        QPushButton:checked { background-color: #ff99c2; }
+        QTextEdit { background-color: #ffffff; color: #d63384; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Неон": """
+        * { font-family: 'Arial'; font-size: 13px; }
+        QMainWindow { background-color: #000000; color: #39ff14; }
+        QPushButton { background-color: #121212; color: #39ff14; border-radius: 6px; padding: 4px; }
+        QPushButton:checked { background-color: #39ff14; color: #000000; }
+        QTextEdit { background-color: #121212; color: #39ff14; border-radius: 6px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Сканди": """
+        * { font-family: 'Segoe UI'; font-size: 13px; }
+        QMainWindow { background-color: #f6f7f6; color: #2d2d2d; }
+        QPushButton { background-color: #e6e7e6; color: #2d2d2d; border-radius: 4px; padding: 4px; }
+        QPushButton:checked { background-color: #cfd0cf; }
+        QTextEdit { background-color: #ffffff; color: #2d2d2d; border-radius: 4px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Моно": """
+        * { font-family: 'Courier New'; font-size: 13px; }
+        QMainWindow { background-color: #222222; color: #dddddd; }
+        QPushButton { background-color: #333333; color: #dddddd; border-radius: 4px; padding: 4px; }
+        QPushButton:checked { background-color: #555555; }
+        QTextEdit { background-color: #111111; color: #dddddd; border-radius: 4px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+    "Винтаж": """
+        * { font-family: 'Georgia'; font-size: 14px; }
+        QMainWindow { background-color: #faf1e6; color: #5e412f; }
+        QPushButton { background-color: #e6d5c3; color: #5e412f; border-radius: 4px; padding: 4px; }
+        QPushButton:checked { background-color: #c9b29b; }
+        QTextEdit { background-color: #ffffff; color: #5e412f; border-radius: 4px; }
+        QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+        QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+    """,
+}
+
+DEFAULT_QSS = """
+    * { font-family: 'Segoe UI'; font-size: 12px; }
+    QMainWindow { background-color: #dcdcdc; color: #202020; }
+    QPushButton { background-color: #ececec; color: #202020; border-radius: 4px; padding: 4px; }
+    QPushButton:checked { background-color: #bdbdbd; }
+    QTextEdit { background-color: #ffffff; color: #202020; border-radius: 4px; }
+    QPushButton#lsButton:checked { border: 2px solid #FFD700; }
+    QPushButton#asyaButton:checked { border: 2px solid #00AAFF; }
+"""
+
+
+def apply_theme(app, name: str) -> None:
+    """Apply theme stylesheet to the QApplication."""
+    if not name or name == "Стандартная":
+        app.setStyleSheet(DEFAULT_QSS)
+    else:
+        app.setStyleSheet(THEME_QSS.get(name, DEFAULT_QSS))

--- a/logic/app_state.py
+++ b/logic/app_state.py
@@ -25,6 +25,8 @@ class UIContext:
         self.current_theme_name = "Светлая"
         self.bg_pixmap = None
         self.bg_path = None
+        self.btn_ls = None
+        self.btn_asya_plus = None
         # OCR settings
         self.ocr_mode = "CPU"  # or "GPU"
 


### PR DESCRIPTION
## Summary
- implement ten visual themes and default fallback
- allow theme selection in settings dialog
- add music dialog and move music button to header
- refactor layout: clipboard row, output controls, and form layout fields
- place LS/Asya+ buttons next to name field

## Testing
- `python -m py_compile gui/main_window.py logic/generator.py gui/settings_window.py gui/themes.py gui/music_dialog.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f234ae2c83318f940fc425f73a18