### PR TITLE
Implement auto generation toggle and settings save options

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QLabel, QVBoxLayout, QHBoxLayout, QPushButton,
-    QTextEdit, QComboBox, QMessageBox, QToolButton, QFormLayout, QCheckBox,
-    QScrollArea, QSpinBox, QGroupBox, QSizePolicy, QSlider
+    QTextEdit, QComboBox, QMessageBox, QToolButton, QFormLayout,
+    QScrollArea, QSpinBox, QGroupBox, QSizePolicy, QSlider, QCheckBox
 )
 from PySide6.QtGui import QPixmap
 from PySide6.QtCore import Qt
@@ -14,6 +14,7 @@ from logic.generator import update_fields, generate_message
 from logic.utils import copy_generated_text, translate_to_english
 from gui.themes import apply_theme
 from gui.animations import setup_animation
+from gui import ToggleSwitch
 
 
 
@@ -191,11 +192,21 @@ class MainWindow(QMainWindow):
         setup_animation(self.trans_btn, ctx)
 
         output_container = QVBoxLayout()
-        self.auto_copy_cb = QCheckBox("📋 Авто-копирование")
-        self.auto_copy_cb.stateChanged.connect(lambda val: setattr(ctx, "auto_copy_enabled", bool(val)))
         top_controls = QHBoxLayout()
         top_controls.addStretch()
-        top_controls.addWidget(self.auto_copy_cb)
+
+        self.auto_copy_sw = ToggleSwitch(tooltip_off="Выкл", tooltip_on="Вкл")
+        self.auto_copy_sw.setChecked(ctx.auto_copy_enabled)
+        self.auto_copy_sw.toggled.connect(lambda val: setattr(ctx, "auto_copy_enabled", bool(val)))
+        self.auto_gen_sw = ToggleSwitch(tooltip_off="Выкл", tooltip_on="Вкл")
+        self.auto_gen_sw.setChecked(ctx.auto_generate_after_autofill)
+        self.auto_gen_sw.toggled.connect(lambda val: setattr(ctx, "auto_generate_after_autofill", bool(val)))
+
+        top_controls.addWidget(QLabel("Авто-копирование"))
+        top_controls.addWidget(self.auto_copy_sw)
+        top_controls.addSpacing(15)
+        top_controls.addWidget(QLabel("Автогенерация после автозаполнения"))
+        top_controls.addWidget(self.auto_gen_sw)
         top_controls.addWidget(self.copy_btn)
         top_controls.addWidget(self.trans_btn)
         output_container.addLayout(top_controls)

--- a/gui/settings_window.py
+++ b/gui/settings_window.py
@@ -12,11 +12,14 @@ from PySide6.QtWidgets import (
     QToolButton,
     QFileDialog,
     QMessageBox,
+    QGroupBox,
+    QFormLayout,
 )
 from PySide6.QtCore import Qt
 
 from logic.app_state import UIContext
 from gui.themes import THEME_QSS, apply_theme
+from gui import ToggleSwitch
 
 
 class SettingsDialog(QDialog):
@@ -103,6 +106,22 @@ class SettingsDialog(QDialog):
         row_music.addWidget(self.music_btn)
         self.settings_layout.addLayout(row_music)
 
+        save_box = QGroupBox("Сохранять")
+        save_layout = QFormLayout(save_box)
+        self.save_theme_sw = ToggleSwitch()
+        self.save_theme_sw.setChecked(ctx.settings.save_theme)
+        save_layout.addRow("Тему", self.save_theme_sw)
+        self.save_ocr_sw = ToggleSwitch()
+        self.save_ocr_sw.setChecked(ctx.settings.save_ocr_mode)
+        save_layout.addRow("OCR (GPU/CPU)", self.save_ocr_sw)
+        self.save_anim_sw = ToggleSwitch()
+        self.save_anim_sw.setChecked(ctx.settings.save_animation_effect)
+        save_layout.addRow("Эффект анимации", self.save_anim_sw)
+        self.save_auto_copy_sw = ToggleSwitch()
+        self.save_auto_copy_sw.setChecked(ctx.settings.save_auto_copy)
+        save_layout.addRow("Автокопирование", self.save_auto_copy_sw)
+        self.settings_layout.addWidget(save_box)
+
         save_btn = QPushButton("Сохранить")
         save_btn.clicked.connect(self.save_and_close)
         main_layout.addWidget(save_btn)
@@ -142,6 +161,13 @@ class SettingsDialog(QDialog):
         """Persist selected settings and close the dialog."""
         self.ctx.settings.theme = self.ctx.current_theme_name
         self.ctx.settings.ocr_mode = self.ctx.ocr_mode
+        self.ctx.settings.animation_effect = self.ctx.animation_effect
+        self.ctx.settings.auto_copy = self.ctx.auto_copy_enabled
+
+        self.ctx.settings.save_theme = self.save_theme_sw.isChecked()
+        self.ctx.settings.save_ocr_mode = self.save_ocr_sw.isChecked()
+        self.ctx.settings.save_animation_effect = self.save_anim_sw.isChecked()
+        self.ctx.settings.save_auto_copy = self.save_auto_copy_sw.isChecked()
         self.ctx.settings.save()
         self.accept()
 

--- a/gui/themes.py
+++ b/gui/themes.py
@@ -214,9 +214,8 @@ THEME_QSS = {
     """,
 }
 
-# Override styling for dialogs so that text is always readable on white
-# backgrounds used by secondary windows like settings or music dialogs.
-DIALOG_QSS = """
+# Override styling for dialogs so that text matches the current theme
+DIALOG_LIGHT_QSS = """
     QDialog {
         background-color: #ffffff;
         color: #000000;
@@ -227,6 +226,20 @@ DIALOG_QSS = """
     QDialog QRadioButton,
     QDialog QToolTip {
         color: #000000;
+    }
+"""
+
+DIALOG_DARK_QSS = """
+    QDialog {
+        background-color: #2e2e2e;
+        color: #f0f0f0;
+    }
+    QDialog QLabel,
+    QDialog QGroupBox::title,
+    QDialog QCheckBox,
+    QDialog QRadioButton,
+    QDialog QToolTip {
+        color: #f0f0f0;
     }
 """
 
@@ -350,7 +363,8 @@ def apply_theme(app, name: str, ctx: Optional[UIContext] = None) -> None:
             combo = COMBO_LIGHT_QSS
             cal = CAL_LIGHT_QSS
     # Always append dialog overrides and extra rules
-    app.setStyleSheet(theme + combo + cal + EXTRA_QSS + DIALOG_QSS)
+    dialog = DIALOG_DARK_QSS if name in DARK_THEMES else DIALOG_LIGHT_QSS
+    app.setStyleSheet(theme + combo + cal + EXTRA_QSS + dialog)
     if ctx is not None:
         path = THEME_BACKGROUNDS.get(name)
         ctx.bg_path = str(path) if path else None

--- a/gui/toggle_switch.py
+++ b/gui/toggle_switch.py
@@ -3,17 +3,19 @@ from PySide6.QtCore import QSize, Qt, QRectF, QPoint
 from PySide6.QtGui import QPainter, QColor
 
 class ToggleSwitch(QCheckBox):
-    """Simple on/off switch widget."""
+    """Simple on/off switch widget with customizable tooltips."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, tooltip_off: str = "Мужской", tooltip_on: str = "Женский", *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.tooltip_off = tooltip_off
+        self.tooltip_on = tooltip_on
         self.setCursor(Qt.PointingHandCursor)
         self.setChecked(False)
         self.toggled.connect(self._update_tooltip)
         self._update_tooltip(self.isChecked())
 
     def _update_tooltip(self, checked: bool) -> None:
-        self.setToolTip("Женский" if checked else "Мужской")
+        self.setToolTip(self.tooltip_on if checked else self.tooltip_off)
 
     def sizeHint(self) -> QSize:
         return QSize(50, 24)

--- a/logic/app_state.py
+++ b/logic/app_state.py
@@ -42,16 +42,23 @@ class UIContext:
         self.settings = UserSettings(settings_path)
 
         # "Винтаж" используется по умолчанию
-        self.current_theme_name = self.settings.theme
+        self.current_theme_name = (
+            self.settings.theme if self.settings.save_theme else "Винтаж"
+        )
         self.bg_pixmap = None
         self.bg_path = None
         self.btn_ls = None
         self.btn_asya_plus = None
         # OCR settings
-        self.ocr_mode = self.settings.ocr_mode  # "CPU" or "GPU"
+        self.ocr_mode = (
+            self.settings.ocr_mode if self.settings.save_ocr_mode else "CPU"
+        )  # "CPU" or "GPU"
 
         # generation helpers
-        self.auto_copy_enabled = False
+        self.auto_copy_enabled = (
+            self.settings.auto_copy if self.settings.save_auto_copy else False
+        )
+        self.auto_generate_after_autofill = False
         self.labels: dict[str, object] = {}
         self.regular_meeting_enabled = False
         self.regular_count = None
@@ -60,7 +67,11 @@ class UIContext:
 
         # animation settings
         self.animations_enabled = True
-        self.animation_effect = "Glow"
+        self.animation_effect = (
+            self.settings.animation_effect
+            if self.settings.save_animation_effect
+            else "Glow"
+        )
         self.animation_intensity = 50
 
         # history of generated templates

--- a/logic/ocr_paddle.py
+++ b/logic/ocr_paddle.py
@@ -349,6 +349,9 @@ def recognize_from_clipboard(ctx: UIContext) -> None:
 
     validated = validate_with_rooms(parsed, rooms_by_bz, fuzzy_threshold=0.6)
     update_gui_fields(validated, ctx, scores=scores)
+    if getattr(ctx, "auto_generate_after_autofill", False):
+        from logic.generator import generate_message
+        generate_message(ctx)
     
 def merge_split_lines(lines: List[Dict]) -> List[Dict]:
     """Merge neighbouring OCR lines that likely belong to the same word."""

--- a/logic/user_settings.py
+++ b/logic/user_settings.py
@@ -9,19 +9,46 @@ class UserSettings:
         self.path = Path(path)
         self.theme = "Винтаж"
         self.ocr_mode = "CPU"
+        self.animation_effect = "Glow"
+        self.auto_copy = False
+
+        self.save_theme = True
+        self.save_ocr_mode = True
+        self.save_animation_effect = True
+        self.save_auto_copy = True
         self.load()
 
     def load(self) -> None:
         if self.path.exists():
             try:
                 data = json.loads(self.path.read_text(encoding="utf-8"))
-                self.theme = data.get("theme", self.theme)
-                self.ocr_mode = data.get("ocr_mode", self.ocr_mode)
+                self.save_theme = data.get("save_theme", True)
+                self.save_ocr_mode = data.get("save_ocr_mode", True)
+                self.save_animation_effect = data.get("save_animation_effect", True)
+                self.save_auto_copy = data.get("save_auto_copy", True)
+
+                if self.save_theme:
+                    self.theme = data.get("theme", self.theme)
+                if self.save_ocr_mode:
+                    self.ocr_mode = data.get("ocr_mode", self.ocr_mode)
+                if self.save_animation_effect:
+                    self.animation_effect = data.get("animation_effect", self.animation_effect)
+                if self.save_auto_copy:
+                    self.auto_copy = data.get("auto_copy", self.auto_copy)
             except Exception:
                 pass
 
     def save(self) -> None:
-        data = {"theme": self.theme, "ocr_mode": self.ocr_mode}
+        data = {
+            "theme": self.theme,
+            "ocr_mode": self.ocr_mode,
+            "animation_effect": self.animation_effect,
+            "auto_copy": self.auto_copy,
+            "save_theme": self.save_theme,
+            "save_ocr_mode": self.save_ocr_mode,
+            "save_animation_effect": self.save_animation_effect,
+            "save_auto_copy": self.save_auto_copy,
+        }
         try:
             self.path.write_text(
                 json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"


### PR DESCRIPTION
## Summary
- add customizable `ToggleSwitch`
- respect saved settings in `UIContext`
- persist additional user settings and flags
- update settings dialog with save toggles
- add auto-generation switch next to auto-copy
- trigger generation after autofill when enabled
- adapt dialog colors to theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480119a89c8326a98b91d705c5b6cb