### PR TITLE
Improve generator and cleanup comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    force=True  # 💥 Вот это критично
+    force=True
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove stray comment from `main.py`
- add Russian docstrings and helper functions in `logic/generator.py`
- refactor `generate_message` into smaller helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebb9d5b188326a76a319ad39aec81