### PR TITLE
Implement telegram link auto-open after auto report

### DIFF
--- a/logic/generator.py
+++ b/logic/generator.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QApplication,
 )
+import webbrowser
 
 try:
     from PySide6.QtCore import QDate, Qt, QTime, QTimer, QEvent
@@ -1148,6 +1149,8 @@ def show_auto_report_dialog(ctx: UIContext) -> bool | None:
         ctx.report_text.setVisible(True)
     if getattr(ctx, "auto_copy_enabled", False):
         copy_generated_text(ctx)
+    if tg:
+        webbrowser.open(tg)
     return True
 
 


### PR DESCRIPTION
## Summary
- open Telegram link automatically after confirming Auto-report
- import webbrowser in generator

## Testing
- `python -m py_compile logic/generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68518dc1368483269e192197d2c6d2e4