### PR TITLE
Fix EasyOCR room handling in Telegram bot

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -5,7 +5,6 @@ from aiogram.types import (
     ReplyKeyboardMarkup,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
-    CallbackQuery,
 )
 
 from .session import SessionStorage
@@ -52,8 +51,8 @@ async def toggle_auto(message: types.Message) -> None:
         session.awaiting_auto_tg = False
         await message.answer("Автоотчёты выключены")
     else:
-        session.awaiting_auto_login = True
-        await message.answer("Введите логин организатора")
+        session.auto_enabled = True
+        await message.answer("Автоотчёты включены")
 
 
 @router.message(lambda m: sessions.get(m.from_user.id).awaiting_auto_login and m.text)
@@ -61,8 +60,13 @@ async def set_auto_login(message: types.Message) -> None:
     session = sessions.get(message.from_user.id)
     session.organizer_login = message.text.strip().lstrip("@")
     session.awaiting_auto_login = False
-    session.awaiting_auto_tg = True
-    await message.answer("Введите ссылку на Telegram организатора")
+    if not session.organizer_tg:
+        session.awaiting_auto_tg = True
+        await message.answer("Введите ссылку на Telegram организатора")
+    elif session.pending_fields:
+        report = build_report(session.pending_fields, session.pending_type, session)
+        await message.answer(report, parse_mode=None)
+        sessions.reset(message.from_user.id)
 
 
 @router.message(lambda m: sessions.get(m.from_user.id).awaiting_auto_tg and m.text)
@@ -70,8 +74,12 @@ async def set_auto_tg(message: types.Message) -> None:
     session = sessions.get(message.from_user.id)
     session.organizer_tg = message.text.strip()
     session.awaiting_auto_tg = False
-    session.auto_enabled = True
-    await message.answer("Автоотчёты включены")
+    if session.pending_fields:
+        report = build_report(session.pending_fields, session.pending_type, session)
+        await message.answer(report, parse_mode=None)
+        sessions.reset(message.from_user.id)
+    else:
+        await message.answer("Сохранено")
 
 
 @router.message(lambda m: m.text in {"Актуализация", "Обмен", "Организация встречи", "Другое"})
@@ -129,29 +137,29 @@ async def handle_image(message: types.Message) -> None:
         )
     else:
         text = "Эта тема пока не поддерживается"
-    buttons = [
-        InlineKeyboardButton(text="Скопировать шаблон", callback_data="copy"),
-    ]
+    buttons: list[InlineKeyboardButton] = []
     if session.auto_enabled and session.organizer_tg:
         buttons.append(
             InlineKeyboardButton(text="Написать организатору", url=session.organizer_tg)
         )
-    markup = InlineKeyboardMarkup(inline_keyboard=[buttons])
-    sent = await message.answer(text, reply_markup=markup)
+    markup = InlineKeyboardMarkup(inline_keyboard=[buttons]) if buttons else None
+    await message.answer(text, reply_markup=markup, parse_mode="Markdown")
     if session.auto_enabled:
-        report = build_report(fields, meeting_type, session)
-        await message.answer(report, parse_mode=None)
-    sessions.reset(message.from_user.id)
-
-
-@router.callback_query(lambda c: c.data == "copy")
-async def copy_template(callback: CallbackQuery) -> None:
-    await callback.answer("Скопировано")
-    await callback.bot.copy_message(
-        chat_id=callback.message.chat.id,
-        from_chat_id=callback.message.chat.id,
-        message_id=callback.message.message_id,
-    )
+        if session.organizer_login and session.organizer_tg:
+            report = build_report(fields, meeting_type, session)
+            await message.answer(report, parse_mode=None)
+            sessions.reset(message.from_user.id)
+        else:
+            session.pending_fields = fields
+            session.pending_type = meeting_type
+            if not session.organizer_login:
+                session.awaiting_auto_login = True
+                await message.answer("Введите логин организатора")
+            else:
+                session.awaiting_auto_tg = True
+                await message.answer("Введите ссылку на Telegram организатора")
+    else:
+        sessions.reset(message.from_user.id)
 
 
 @router.message()

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -60,13 +60,8 @@ async def set_auto_login(message: types.Message) -> None:
     session = sessions.get(message.from_user.id)
     session.organizer_login = message.text.strip().lstrip("@")
     session.awaiting_auto_login = False
-    if not session.organizer_tg:
-        session.awaiting_auto_tg = True
-        await message.answer("Введите ссылку на Telegram организатора")
-    elif session.pending_fields:
-        report = build_report(session.pending_fields, session.pending_type, session)
-        await message.answer(report, parse_mode=None)
-        sessions.reset(message.from_user.id)
+    session.awaiting_auto_tg = True
+    await message.answer("Введите ссылку на Telegram организатора")
 
 
 @router.message(lambda m: sessions.get(m.from_user.id).awaiting_auto_tg and m.text)
@@ -74,6 +69,20 @@ async def set_auto_tg(message: types.Message) -> None:
     session = sessions.get(message.from_user.id)
     session.organizer_tg = message.text.strip()
     session.awaiting_auto_tg = False
+    if session.main_message_id:
+        markup = InlineKeyboardMarkup(
+            inline_keyboard=[[
+                InlineKeyboardButton(text="Написать организатору", url=session.organizer_tg)
+            ]]
+        )
+        try:
+            await message.bot.edit_message_reply_markup(
+                chat_id=message.chat.id,
+                message_id=session.main_message_id,
+                reply_markup=markup,
+            )
+        except Exception:
+            pass
     if session.pending_fields:
         report = build_report(session.pending_fields, session.pending_type, session)
         await message.answer(report, parse_mode=None)
@@ -129,37 +138,105 @@ async def handle_image(message: types.Message) -> None:
     file_bytes = await message.bot.download(file.file_id)
     data = file_bytes.getvalue()
     fields, meeting_type = await process_image(data)
+    session.pending_fields = fields
+    session.pending_type = meeting_type
+    session.awaiting_mode = True
+    markup = InlineKeyboardMarkup(
+        inline_keyboard=[[
+            InlineKeyboardButton(text="Ася", callback_data="mode_asya"),
+            InlineKeyboardButton(text="Личное сообщение", callback_data="mode_ls"),
+        ]]
+    )
+    await message.answer("Выберите стиль сообщения:", reply_markup=markup)
+
+
+@router.callback_query(lambda c: c.data in {"mode_asya", "mode_ls"})
+async def choose_mode(callback: types.CallbackQuery) -> None:
+    await callback.answer()
+    session = sessions.get(callback.from_user.id)
+    if not session.pending_fields:
+        await callback.message.answer("Данные не найдены, отправь скриншот заново")
+        return
+    asya = callback.data == "mode_asya"
+    speaker_name = None
+    speaker_gender = None
+    if not asya:
+        if session.user_gender is None:
+            session.awaiting_gender = True
+            markup = InlineKeyboardMarkup(
+                inline_keyboard=[[
+                    InlineKeyboardButton(text="Мужской", callback_data="gender_m"),
+                    InlineKeyboardButton(text="Женский", callback_data="gender_f"),
+                ]]
+            )
+            await callback.message.answer(
+                "Выберите свой пол:", reply_markup=markup
+            )
+            return
+        speaker_name = callback.from_user.first_name
+        speaker_gender = session.user_gender
+    fields = session.pending_fields
+    meeting_type = session.pending_type
     if session.theme == "Актуализация":
-        text = build_actualization_message(fields, meeting_type, session.meeting_link)
+        text = build_actualization_message(
+            fields,
+            meeting_type,
+            session.meeting_link,
+            speaker_name,
+            speaker_gender,
+        )
     elif session.theme == "Обмен":
         text = build_exchange_message(
-            fields, meeting_type, session.my_room or "", session.meeting_link
+            fields,
+            meeting_type,
+            session.my_room or "",
+            session.meeting_link,
+            speaker_name,
+            speaker_gender,
         )
     else:
         text = "Эта тема пока не поддерживается"
-    buttons: list[InlineKeyboardButton] = []
-    if session.auto_enabled and session.organizer_tg:
-        buttons.append(
-            InlineKeyboardButton(text="Написать организатору", url=session.organizer_tg)
-        )
-    markup = InlineKeyboardMarkup(inline_keyboard=[buttons]) if buttons else None
-    await message.answer(text, reply_markup=markup, parse_mode="Markdown")
+    sent = await callback.message.answer(text, parse_mode="Markdown")
+    session.main_message_id = sent.message_id
     if session.auto_enabled:
-        if session.organizer_login and session.organizer_tg:
-            report = build_report(fields, meeting_type, session)
-            await message.answer(report, parse_mode=None)
-            sessions.reset(message.from_user.id)
-        else:
-            session.pending_fields = fields
-            session.pending_type = meeting_type
-            if not session.organizer_login:
-                session.awaiting_auto_login = True
-                await message.answer("Введите логин организатора")
-            else:
-                session.awaiting_auto_tg = True
-                await message.answer("Введите ссылку на Telegram организатора")
+        session.awaiting_auto_login = True
+        await callback.message.answer("Введите логин организатора")
     else:
-        sessions.reset(message.from_user.id)
+        sessions.reset(callback.from_user.id)
+
+
+@router.callback_query(lambda c: c.data in {"gender_m", "gender_f"})
+async def set_gender(callback: types.CallbackQuery) -> None:
+    await callback.answer()
+    session = sessions.get(callback.from_user.id)
+    session.user_gender = "м" if callback.data == "gender_m" else "ж"
+    session.awaiting_gender = False
+    fields = session.pending_fields
+    meeting_type = session.pending_type
+    if not fields:
+        await callback.message.answer("Данные не найдены, отправь скриншот заново")
+        return
+    text = build_actualization_message(
+        fields,
+        meeting_type,
+        session.meeting_link,
+        callback.from_user.first_name,
+        session.user_gender,
+    ) if session.theme == "Актуализация" else build_exchange_message(
+        fields,
+        meeting_type,
+        session.my_room or "",
+        session.meeting_link,
+        callback.from_user.first_name,
+        session.user_gender,
+    )
+    sent = await callback.message.answer(text, parse_mode="Markdown")
+    session.main_message_id = sent.message_id
+    if session.auto_enabled:
+        session.awaiting_auto_login = True
+        await callback.message.answer("Введите логин организатора")
+    else:
+        sessions.reset(callback.from_user.id)
 
 
 @router.message()

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1,9 +1,20 @@
 from aiogram import Router, types
-from aiogram.filters import CommandStart
-from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
+from aiogram.filters import CommandStart, Command
+from aiogram.types import (
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    CallbackQuery,
+)
 
 from .session import SessionStorage
-from .utils import process_image, build_actualization_message, build_exchange_message
+from .utils import (
+    process_image,
+    build_actualization_message,
+    build_exchange_message,
+    build_report,
+)
 
 router = Router()
 
@@ -32,12 +43,53 @@ async def cmd_start(message: types.Message) -> None:
     )
 
 
+@router.message(Command("auto"))
+async def toggle_auto(message: types.Message) -> None:
+    session = sessions.get(message.from_user.id)
+    if session.auto_enabled or session.awaiting_auto_login or session.awaiting_auto_tg:
+        session.auto_enabled = False
+        session.awaiting_auto_login = False
+        session.awaiting_auto_tg = False
+        await message.answer("Автоотчёты выключены")
+    else:
+        session.awaiting_auto_login = True
+        await message.answer("Введите логин организатора")
+
+
+@router.message(lambda m: sessions.get(m.from_user.id).awaiting_auto_login and m.text)
+async def set_auto_login(message: types.Message) -> None:
+    session = sessions.get(message.from_user.id)
+    session.organizer_login = message.text.strip().lstrip("@")
+    session.awaiting_auto_login = False
+    session.awaiting_auto_tg = True
+    await message.answer("Введите ссылку на Telegram организатора")
+
+
+@router.message(lambda m: sessions.get(m.from_user.id).awaiting_auto_tg and m.text)
+async def set_auto_tg(message: types.Message) -> None:
+    session = sessions.get(message.from_user.id)
+    session.organizer_tg = message.text.strip()
+    session.awaiting_auto_tg = False
+    session.auto_enabled = True
+    await message.answer("Автоотчёты включены")
+
+
 @router.message(lambda m: m.text in {"Актуализация", "Обмен", "Организация встречи", "Другое"})
 async def theme_selected(message: types.Message) -> None:
     session = sessions.get(message.from_user.id)
     session.theme = message.text
     session.my_room = None
     session.awaiting_my_room = False
+    session.meeting_link = None
+    session.awaiting_link = True
+    await message.answer("Вставьте ссылку на встречу")
+
+
+@router.message(lambda m: sessions.get(m.from_user.id).awaiting_link and m.text)
+async def set_meeting_link(message: types.Message) -> None:
+    session = sessions.get(message.from_user.id)
+    session.meeting_link = message.text.strip()
+    session.awaiting_link = False
     if session.theme == "Обмен":
         session.awaiting_my_room = True
         await message.answer("Введите название вашей переговорки")
@@ -59,6 +111,9 @@ async def handle_image(message: types.Message) -> None:
     if not session.theme:
         await message.answer("Сначала выбери тему, братан \uD83D\uDE0E")
         return
+    if session.awaiting_link:
+        await message.answer("Сначала отправь ссылку на встречу")
+        return
     if session.theme == "Обмен" and session.awaiting_my_room:
         await message.answer("Сначала отправь название своей переговорки")
         return
@@ -67,13 +122,36 @@ async def handle_image(message: types.Message) -> None:
     data = file_bytes.getvalue()
     fields, meeting_type = await process_image(data)
     if session.theme == "Актуализация":
-        text = build_actualization_message(fields, meeting_type)
+        text = build_actualization_message(fields, meeting_type, session.meeting_link)
     elif session.theme == "Обмен":
-        text = build_exchange_message(fields, meeting_type, session.my_room or "")
+        text = build_exchange_message(
+            fields, meeting_type, session.my_room or "", session.meeting_link
+        )
     else:
         text = "Эта тема пока не поддерживается"
-    await message.answer(text)
+    buttons = [
+        InlineKeyboardButton(text="Скопировать шаблон", callback_data="copy"),
+    ]
+    if session.auto_enabled and session.organizer_tg:
+        buttons.append(
+            InlineKeyboardButton(text="Написать организатору", url=session.organizer_tg)
+        )
+    markup = InlineKeyboardMarkup(inline_keyboard=[buttons])
+    sent = await message.answer(text, reply_markup=markup)
+    if session.auto_enabled:
+        report = build_report(fields, meeting_type, session)
+        await message.answer(report, parse_mode=None)
     sessions.reset(message.from_user.id)
+
+
+@router.callback_query(lambda c: c.data == "copy")
+async def copy_template(callback: CallbackQuery) -> None:
+    await callback.answer("Скопировано")
+    await callback.bot.copy_message(
+        chat_id=callback.message.chat.id,
+        from_chat_id=callback.message.chat.id,
+        message_id=callback.message.message_id,
+    )
 
 
 @router.message()

--- a/bot/session.py
+++ b/bot/session.py
@@ -5,6 +5,13 @@ class Session:
     theme: str | None = None
     my_room: str | None = None
     awaiting_my_room: bool = False
+    meeting_link: str | None = None
+    awaiting_link: bool = False
+    auto_enabled: bool = False
+    awaiting_auto_login: bool = False
+    awaiting_auto_tg: bool = False
+    organizer_login: str | None = None
+    organizer_tg: str | None = None
 
 
 class SessionStorage:
@@ -18,5 +25,11 @@ class SessionStorage:
 
     def reset(self, user_id: int) -> None:
         if user_id in self._sessions:
-            self._sessions[user_id] = Session()
+            current = self._sessions[user_id]
+            preserved = Session(
+                auto_enabled=current.auto_enabled,
+                organizer_login=current.organizer_login,
+                organizer_tg=current.organizer_tg,
+            )
+            self._sessions[user_id] = preserved
 

--- a/bot/session.py
+++ b/bot/session.py
@@ -12,6 +12,8 @@ class Session:
     awaiting_auto_tg: bool = False
     organizer_login: str | None = None
     organizer_tg: str | None = None
+    pending_fields: dict | None = None
+    pending_type: str | None = None
 
 
 class SessionStorage:

--- a/bot/session.py
+++ b/bot/session.py
@@ -14,6 +14,10 @@ class Session:
     organizer_tg: str | None = None
     pending_fields: dict | None = None
     pending_type: str | None = None
+    awaiting_mode: bool = False
+    awaiting_gender: bool = False
+    user_gender: str | None = None
+    main_message_id: int | None = None
 
 
 class SessionStorage:
@@ -28,10 +32,6 @@ class SessionStorage:
     def reset(self, user_id: int) -> None:
         if user_id in self._sessions:
             current = self._sessions[user_id]
-            preserved = Session(
-                auto_enabled=current.auto_enabled,
-                organizer_login=current.organizer_login,
-                organizer_tg=current.organizer_tg,
-            )
+            preserved = Session(auto_enabled=current.auto_enabled)
             self._sessions[user_id] = preserved
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -47,7 +47,9 @@ def build_greeting(name: str) -> Tuple[str, str]:
     return greeting, gender
 
 
-def build_actualization_message(fields: Dict[str, str], meeting_type: str) -> str:
+def build_actualization_message(
+    fields: Dict[str, str], meeting_type: str, meeting_link: str | None
+) -> str:
     greeting, gender = build_greeting(fields.get("name", ""))
     thanks_word = "признателен" if gender == "м" else "признательна"
     myself_word = "сам" if gender == "м" else "сама"
@@ -71,11 +73,12 @@ def build_actualization_message(fields: Dict[str, str], meeting_type: str) -> st
         meeting_type,
         thanks_word,
         myself_word,
+        meeting_link,
     )
 
 
 def build_exchange_message(
-    fields: Dict[str, str], meeting_type: str, my_room: str
+    fields: Dict[str, str], meeting_type: str, my_room: str, meeting_link: str | None
 ) -> str:
     greeting, gender = build_greeting(fields.get("name", ""))
     thanks_word = "признателен" if gender == "м" else "признательна"
@@ -101,5 +104,25 @@ def build_exchange_message(
         meeting_type,
         thanks_word,
         myself_word,
+        meeting_link,
+    )
+
+
+def build_report(fields: Dict[str, str], meeting_type: str, session: Any) -> str:
+    """Create text for auto report based on fields and session."""
+    date = fields.get("date", "")
+    start = fields.get("start", "")
+    end = fields.get("end", "")
+    time = f"{start} — {end}" if start and end else start
+    if session.theme == "Обмен":
+        return (
+            f"Предлагаю обмен по [встрече]({session.meeting_link}), которая пройдёт {date}, в {time} "
+            f"в переговорной **{fields.get('room', '')}** на свою **{session.my_room}**. "
+            f"Пишу @{session.organizer_login}\n[Моё сообщение в Telegram]({session.organizer_tg}).\nОтвет: "
+        )
+    return (
+        f"Уточняю актуальность по [встрече]({session.meeting_link}), которая пройдёт {date} "
+        f"в {time} в переговорной **{fields.get('room', '')}** у @{session.organizer_login}\n"
+        f"[Моё сообщение в Telegram]({session.organizer_tg}).\nОтвет: "
     )
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -6,7 +6,12 @@ from PIL import Image
 import torch
 
 from constants import rooms_by_bz
-from logic.ocr_paddle import run_ocr, parse_fields, validate_with_rooms
+from logic.ocr_paddle import (
+    run_ocr,
+    parse_fields,
+    validate_with_rooms,
+    choose_longer_room,
+)
 from logic.generator import (
     _generate_actualization,
     _generate_exchange,
@@ -28,7 +33,10 @@ async def process_image(data: bytes) -> Tuple[Dict[str, str], str]:
     img = Image.open(io.BytesIO(data)).convert("RGB")
     lines, meeting_type = run_ocr(img, use_gpu=gpu_available())
     parsed = parse_fields(lines)
-    validated = validate_with_rooms(parsed, rooms_by_bz)
+    if parsed.get("room_raw"):
+        texts = [l["text"] for l in lines]
+        parsed["room_raw"] = choose_longer_room(parsed["room_raw"], texts)
+    validated = validate_with_rooms(parsed, rooms_by_bz, fuzzy_threshold=0.6)
     return validated, meeting_type
 
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -40,17 +40,29 @@ async def process_image(data: bytes) -> Tuple[Dict[str, str], str]:
     return validated, meeting_type
 
 
-def build_greeting(name: str) -> Tuple[str, str]:
-    """Simplified greeting builder returning greeting and gender (always male)."""
-    greeting = f"Привет, {name}!"
-    gender = "м"
+def build_greeting(
+    name: str, speaker_name: str | None = None, speaker_gender: str | None = None
+) -> Tuple[str, str]:
+    """Return greeting text and gender using optional speaker info."""
+    if speaker_name:
+        greeting = f"Привет, {name}! Я {speaker_name}, ассистент. Приятно познакомиться!"
+        gender = speaker_gender or "ж"
+    else:
+        greeting = f"Привет, {name}!"
+        gender = "ж"
     return greeting, gender
 
 
 def build_actualization_message(
-    fields: Dict[str, str], meeting_type: str, meeting_link: str | None
+    fields: Dict[str, str],
+    meeting_type: str,
+    meeting_link: str | None,
+    speaker_name: str | None = None,
+    speaker_gender: str | None = None,
 ) -> str:
-    greeting, gender = build_greeting(fields.get("name", ""))
+    greeting, gender = build_greeting(
+        fields.get("name", ""), speaker_name, speaker_gender
+    )
     thanks_word = "признателен" if gender == "м" else "признательна"
     myself_word = "сам" if gender == "м" else "сама"
 
@@ -78,9 +90,16 @@ def build_actualization_message(
 
 
 def build_exchange_message(
-    fields: Dict[str, str], meeting_type: str, my_room: str, meeting_link: str | None
+    fields: Dict[str, str],
+    meeting_type: str,
+    my_room: str,
+    meeting_link: str | None,
+    speaker_name: str | None = None,
+    speaker_gender: str | None = None,
 ) -> str:
-    greeting, gender = build_greeting(fields.get("name", ""))
+    greeting, gender = build_greeting(
+        fields.get("name", ""), speaker_name, speaker_gender
+    )
     thanks_word = "признателен" if gender == "м" else "признательна"
     myself_word = "сам" if gender == "м" else "сама"
 

--- a/logic/generator.py
+++ b/logic/generator.py
@@ -656,10 +656,22 @@ def _make_time_part(start: str, end: str) -> str:
     return ""
 
 
-def _generate_actualization(greeting: str, formatted: str, time_part: str, link_part: str,
-                            room: str, regular: str, thanks_word: str, myself_word: str) -> str:
+def _generate_actualization(
+    greeting: str,
+    formatted: str,
+    time_part: str,
+    link_part: str,
+    room: str,
+    regular: str,
+    thanks_word: str,
+    myself_word: str,
+    meeting_link: str | None = None,
+) -> str:
     """Собрать сообщение для запроса актуальности."""
     is_regular = "регулярная встреча" if regular.lower() == "регулярная" else "встреча"
+    if meeting_link:
+        is_regular = f"[{is_regular}]({meeting_link})"
+        link_part = ""
     share_word = "разово поделиться" if regular.lower() == "регулярная" else "поделиться"
     return (
         f"{greeting}\n\n"
@@ -670,11 +682,23 @@ def _generate_actualization(greeting: str, formatted: str, time_part: str, link_
     )
 
 
-def _generate_exchange(greeting: str, formatted: str, time_part: str, link_part: str,
-                       his_room: str, my_room: str, regular: str,
-                       thanks_word: str, myself_word: str) -> str:
+def _generate_exchange(
+    greeting: str,
+    formatted: str,
+    time_part: str,
+    link_part: str,
+    his_room: str,
+    my_room: str,
+    regular: str,
+    thanks_word: str,
+    myself_word: str,
+    meeting_link: str | None = None,
+) -> str:
     """Собрать сообщение для предложения обмена."""
     is_regular = "регулярная встреча" if regular.lower() == "регулярная" else "встреча"
+    if meeting_link:
+        is_regular = f"[{is_regular}]({meeting_link})"
+        link_part = ""
     share_word = "разово обменяться" if regular.lower() == "регулярная" else "обменяться"
     return (
         f"{greeting}\n\n"


### PR DESCRIPTION
## Summary
- import `choose_longer_room` for Telegram bot utils
- prefer longer OCR matches before fuzzy matching
- loosen fuzzy matching threshold when validating rooms

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68693183cd9c8326b887ebd51e72eb13